### PR TITLE
Cleanup

### DIFF
--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -28,5 +28,5 @@ spec:
         args: []
         env:
         - name: REGISTRY_SECRET_NAMES
-          value: "registry-secret-1,registry-secret-2"
+          value: "" # This must be filled in for ips-sa-p to function; see README
         resources: {}

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 		}
 
 		for _, sa := range serviceAccounts.Items {
-			log.WithField("serviceaccount", sa.Name).WithField("namesapce", sa.Namespace).
+			log.WithField("serviceaccount", sa.Name).WithField("namespace", sa.Namespace).
 				Debug("Processing ServiceAccount")
 
 			for _, privateReg := range privateRegistries {
@@ -58,12 +58,12 @@ func main() {
 
 				if includeImagePullSecret(&sa, privateReg.name) {
 					log.WithField("serviceaccount", sa.Name).
-						WithField("namesapce", sa.Namespace).
+						WithField("namespace", sa.Namespace).
 						WithField("imagePullSecrets", sa.ImagePullSecrets).
 						Debug("ServiceAccount has ImagePullSecrets")
 				} else {
 					log.WithField("serviceaccount", sa.Name).
-						WithField("namesapce", sa.Namespace).
+						WithField("namespace", sa.Namespace).
 						WithField("imagePullSecret", privateReg.name).
 						Info("ServiceAccount does not have ImagePullSecret")
 
@@ -75,7 +75,7 @@ func main() {
 					result, err := client.CoreV1().ServiceAccounts(sa.Namespace).
 						Patch(context.TODO(), sa.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{})
 					log.WithField("serviceaccount", result.Name).
-						WithField("namesapce", sa.Namespace).
+						WithField("namespace", sa.Namespace).
 						WithField("imagePullSecrets", result.ImagePullSecrets).
 						Info("ServiceAccount patched")
 					if err != nil {


### PR DESCRIPTION
- Fix 'namesapce' -> 'namespace'
- Don't provide "example" (junk) secret names in the deployment environment variable. Instead, leave a comment in the deployment file and allow the program exit with an error in the logs instructing to set the environment variable.