### PR TITLE
Add multi-platform build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
+FROM golang:latest
+WORKDIR /src
+COPY ./ /src
+RUN GOOS=linux go build -o ./dist/app .
+
 FROM debian
-LABEL MAINTAINER="Thorsten Hersam <thorsten.hersam@neutryno.de>"
-COPY ./dist/app /app
+COPY --from=0 /src/dist/app /app
 ENTRYPOINT /app

--- a/README.md
+++ b/README.md
@@ -36,6 +36,5 @@ kubectl apply -f https://raw.githubusercontent.com/neutryno/imagepullsecret-serv
 
 ## Build
 ```bash
-GOOS=linux go build -o ./dist/app .
-docker build . -t neutryno/imagepullsecret-serviceaccount-patcher
+docker buildx build . -t neutryno/imagepullsecret-serviceaccount-patcher --platform linux/amd64,linux/arm64 --no-cache
 ```


### PR DESCRIPTION
Add docker buildx build for project to generate multi-platform docker images for linux/amd64 and linux/arm64 architectures