### PR TITLE
create a minimal container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:latest
+FROM golang:latest AS builder
 WORKDIR /src
 COPY ./ /src
-RUN GOOS=linux go build -o ./dist/app .
+RUN CGO_ENABLED=0 GOOS=linux go build -o ./dist/app .
 
-FROM debian
-COPY --from=0 /src/dist/app /app
+FROM scratch AS runtime
+COPY --from=builder /src/dist/app /app
 ENTRYPOINT /app


### PR DESCRIPTION
This PR minimizes the size of the container image by compiling the application with `CGO_ENABLED=0` and copying the binary to a scratch image.

ca-certificates are not necessary because the application has no external connection.